### PR TITLE
Prove no_add_or_change_if_stock_zero

### DIFF
--- a/ShoppingCart.lean
+++ b/ShoppingCart.lean
@@ -200,7 +200,24 @@ theorem no_add_or_change_if_stock_zero
   q > 0) →
   (operationalSemantics (Command.AddItem i) (sc, s) = sc ∧
    operationalSemantics (Command.ChangeQuantity i q) (sc, s) = sc) :=
-   by sorry
+  by
+  intros H0
+  have H1 := H0.left
+  have H2 := H0.right
+  have left : operationalSemantics (Command.AddItem i) (sc, s) = sc :=
+    by
+    rw [operationalSemantics]
+    simp
+    rw [H1]
+    simp
+  have right : operationalSemantics (Command.ChangeQuantity i q) (sc, s) = sc :=
+    by
+    rw [operationalSemantics]
+    simp
+    rw [H1]
+    intro contra
+    simp_all
+  simp_all
 
 -- if my checkout function (an implementation in lean) evaluates to true then the operational semantics for the Checkout command (specification) 
 -- evaluates to (0,0,0,0,0,0,0) given the same cart and stock.

--- a/ShoppingCart.lean
+++ b/ShoppingCart.lean
@@ -192,6 +192,12 @@ theorem cart_less_than_stock (sc : ShoppingCart) (s : Stock) :
 
 -- You can't add an item to the cart, or set its quantity to a nonzero value, if
 -- that item is not in stock.
+theorem no_add_or_change_if_stock_zero
+  (sc : ShoppingCart) (s : Stock) (i: Item) (q : Nat) :
+  (getItem s i = 0 ∧
+  -- We need this clause because otherwise q could itself be zero, and changing
+  -- the item's quantity would then be allowed.
+  q > 0) →
   (operationalSemantics (Command.AddItem i) (sc, s) = sc ∧
    operationalSemantics (Command.ChangeQuantity i q) (sc, s) = sc) :=
    by sorry

--- a/ShoppingCart.lean
+++ b/ShoppingCart.lean
@@ -190,9 +190,8 @@ theorem cart_less_than_stock (sc : ShoppingCart) (s : Stock) :
   (¬ ∃ i : Item, getItem sc i > getItem s i) :=
   by sorry
 
--- you cant add an item to the cart ( or change the number of items) that doesnt correspond to the stock.
-theorem no_add_or_change_if_stock_zero (sc : ShoppingCart) (s : Stock) (i: Item)  (q : Nat) :
-  getItem s i = 0 →
+-- You can't add an item to the cart, or set its quantity to a nonzero value, if
+-- that item is not in stock.
   (operationalSemantics (Command.AddItem i) (sc, s) = sc ∧
    operationalSemantics (Command.ChangeQuantity i q) (sc, s) = sc) :=
    by sorry


### PR DESCRIPTION
Slightly tweak the theorem for `no_add_or_change_if_stock_zero` and add a proof for it.

I have modified the theorem slightly to require that the quantity we are changing the value to is greater than zero, because otherwise the theorem would be unprovable (since a user could change an item's quantity to zero and the ChangeQuantity command would succeed).